### PR TITLE
feat: check modifyTimeStamp before check cotent hash

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,15 @@
 import { program } from 'commander'
 import consola from 'consola'
 import { PROJECT_NAME } from './constant'
-import { calcHash, checkHash, getPackageManager, storeHash } from '.'
+import {
+  calcHash,
+  calcModifyTimeStamps,
+  checkHash,
+  checkModifyTimeStamps,
+  getPackageManager,
+  storeHash,
+  storeModifyTimeStamps,
+} from '.'
 import type { PackageManager } from './constant'
 
 program.option('-u, --update')
@@ -12,11 +20,12 @@ run()
 
 export async function update(pm: PackageManager) {
   await storeHash(await calcHash(pm))
+  await storeModifyTimeStamps(await calcModifyTimeStamps(pm))
   consola.success('Successfully store the dependency hash')
 }
 
 export async function check(pm: PackageManager) {
-  if (!(await checkHash(pm))) {
+  if (!(await checkModifyTimeStamps(pm)) && !(await checkHash(pm))) {
     const installCommand = {
       npm: 'npm install',
       yarn: 'yarn',

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest'
-import { checkHash, getPackageManager } from '../src'
+import { checkHash, checkModifyTimeStamps, getPackageManager } from '../src'
 
 test('getPackageManager', async () => {
   expect(await getPackageManager()).toBe('pnpm')
@@ -8,4 +8,9 @@ test('getPackageManager', async () => {
 test('checkHash', async () => {
   const pm = await getPackageManager()
   expect(await checkHash(pm)).toBe(true)
+})
+
+test('checkModifyTimeStamps', async () => {
+  const pm = await getPackageManager()
+  expect(await checkModifyTimeStamps(pm)).toBe(true)
 })


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Most of the time, we can check modifyTimeStamp first，If the modifyTimeStamp does not change, the file does not change。

Generating and comparing hash is expensive。

The same scheme is used in my library. If you are interested, you can see 👉 [file-computed](https://github.com/dishait/file-computed)
