### PR TITLE
chore: add npx command to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,19 @@
 
 Check if your `node_modules` is stale.
 
-### Running on-demand:
+### Running on-demand
 
 Using `npx` you can run the script without installing it first:
 
-    npx stale-dep
+```bash
+npx stale-dep
+```
 
 ## Usage
 
 `stale-dep -u`: store the current dependencies status.
 
 `stale-dep`: check if dependencies status is changed comparing to previous stored.
-
 
 ### Add `stale-dep` to the project
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,18 @@
 
 Check if your `node_modules` is stale.
 
+### Running on-demand:
+
+Using `npx` you can run the script without installing it first:
+
+    npx stale-dep
+
 ## Usage
 
 `stale-dep -u`: store the current dependencies status.
 
 `stale-dep`: check if dependencies status is changed comparing to previous stored.
+
 
 ### Add `stale-dep` to the project
 


### PR DESCRIPTION
### Description

Adds `npx` command to README so that you try it out seconds after finding the repo.

### Linked Issues

None

### Additional context

May not be in exactly the right place within the README, so feel free to let me know where or move it to where you would like it.
